### PR TITLE
key inputs only register on press

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -41,7 +41,9 @@ impl Game {
             _ => {},
         }
 
-        self.scene.update(key);
+        if key.is_some() && key.unwrap().pressed {
+            self.scene.update(key);
+        }
         return game_data;
     }
 


### PR DESCRIPTION
Addresses issue #13 

Key strokes were being registered on key release and key press. Now they are only registered on presses